### PR TITLE
Fix map name case

### DIFF
--- a/map/games/Invasion_USA-Apocalypse_1.0.1.xml
+++ b/map/games/Invasion_USA-Apocalypse_1.0.1.xml
@@ -1823,7 +1823,7 @@
         </property>
 
                 <!-- Map Name: also used for map utils when asked -->
-                <property name="mapName" value="Invasion_USA" editable="false"/>
+                <property name="mapName" value="invasion_usa" editable="false"/>
 
 		<property name="notes"> 
 		<value>

--- a/map/games/Invasion_USA_1.5.0.xml
+++ b/map/games/Invasion_USA_1.5.0.xml
@@ -1699,7 +1699,7 @@
         </property>
 
                 <!-- Map Name: also used for map utils when asked -->
-                <property name="mapName" value="Invasion_USA" editable="false"/>
+                <property name="mapName" value="invasion_usa" editable="false"/>
 
 		<property name="notes"> 
 		<value>

--- a/map/games/UnderSiege_America.xml
+++ b/map/games/UnderSiege_America.xml
@@ -7165,7 +7165,7 @@
 		</property>
 
 		<!-- Map Name: also used for map utils when asked -->
-		<property name="mapName" value="Invasion_USA" editable="false">
+		<property name="mapName" value="invasion_usa" editable="false">
 			<string/>
 		</property>
 


### PR DESCRIPTION
This PR addresses `triplea-game/triplea` issue [#1560](https://github.com/triplea-game/triplea/issues/1560).

The root cause of the problem is the value of the `mapName` property does not match the case of the corresponding folder in the file system and/or zip archive.  TripleA fails to load this map in all cases except on Windows when the map shape is a directory (due to the case-insensitive nature of the Windows file system).

This PR simply changes the case of the `mapName` property value to match the repo name.  I manually verified I could load this map after the change.